### PR TITLE
fix(xt): use import.meta.glob to dynamically load modules

### DIFF
--- a/src/xt.mjs
+++ b/src/xt.mjs
@@ -437,9 +437,10 @@ if (typeof window !== 'undefined') {
    * @param {Boolean} params.observer If load with IntersectionObserver
    */
   Xt._load = ({ container, name, suffix, observer } = {}) => {
+    const modules = import.meta.glob('./modules/*.mjs');
     let promise
     if (!Xt[name].loaded[name]) {
-      promise = import(`./modules/${name.toLowerCase()}${suffix}.mjs`).then(module => {
+      promise = modules[`./modules/${name.toLowerCase()}${suffix}.mjs`]().then(module => {
         if (!Xt[name].loaded[name]) {
           Xt[name].loaded[name] = true
           Object.setPrototypeOf(Xt[name].prototype, module[`${name}${suffix}`].prototype)


### PR DESCRIPTION
Hello @minimit :)

Context:
* I use this library in an [Astro](https://docs.astro.build/en/guides/client-side-scripts/#using-script-in-astro) project. The following code produce ` error loading dynamically imported module: http://localhost:4321/assets/modules/toggleInit.mjs` error:
```astro
<script>
  import "xtendui/src/toggle";
  import "xtendui/src/overlay";
</script>
```

Problem:
* Vite (and other build tools) doesn't support dynamic imports with variables

Solution:
* Use `import.meta.glob` to allow vite to detect and bundle dynamically imported files. With the help of ChatGpt: https://chatgpt.com/share/6772c5e9-7c7c-800c-ab12-bb6b287bc3f1

<!--
Make a better world one commit at time!
Please make sure to read the Pull Request Guidelines:
https://github.com/xtendui/xtendui/blob/master/.github/CONTRIBUTING.md
-->
